### PR TITLE
Example to show requireing in test.p6 directly works

### DIFF
--- a/test.p6
+++ b/test.p6
@@ -1,5 +1,4 @@
 #!/usr/bin/env perl6
 use v6;
 use lib "lib";
-use C::A;
-C::A.run;
+require ::("C::B");


### PR DESCRIPTION
Same `require` works if it's in the script file, not in the module `C::A`.

```
> perl6 -v
This is Rakudo version 2016.12-239-gc405f0672 built on MoarVM version 2016.12-71-g331a6b43
implementing Perl 6.c.
> perl6 test.p6
```

<details>
<summary>(this version of `perl6` cannot run `test.pm6` in master branch properly)</summary>
```
[github.com/skaji/Crust-issue]$ perl6 -v
This is Rakudo version 2016.12-239-gc405f0672 built on MoarVM version 2016.12-71-g331a6b43
implementing Perl 6.c.
[github.com/skaji/Crust-issue]$ perl6 test.p6
No such symbol 'C::B'
  in method run at /Users/astj/.ghq/github.com/skaji/Crust-issue/lib/C/A.pm6 (C::A) line 5
  in block <unit> at test.p6 line 5

Actually thrown at:
  in block <unit> at test.p6 line 5
```
</details>