### PR TITLE
Example for a workaround to load the module in caller

### DIFF
--- a/test.p6
+++ b/test.p6
@@ -2,4 +2,5 @@
 use v6;
 use lib "lib";
 use C::A;
+use C::B;
 C::A.run;


### PR DESCRIPTION
If `C::B` is loaded in the caller, this script successes.

```
> perl6 -v
This is Rakudo version 2016.12-239-gc405f0672 built on MoarVM version 2016.12-71-g331a6b43
implementing Perl 6.c.
> perl6 test.p6
>
```